### PR TITLE
Update `restroom.ts` with facility attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sozialhelden/ac-format",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "",
   "keywords": [],
   "main": "dist/ac-format.umd.js",

--- a/src/restroom.ts
+++ b/src/restroom.ts
@@ -85,6 +85,11 @@ export const RestroomSchema = createSchemaInstance(
       optional: true,
       accessibility: {}
     },
+    'mirror.isLocatedInsideRestroom': {
+      type: Boolean,
+      optional: true,
+      accessibility: {}
+    },
     'mirror.isAccessibleWhileSeated': {
       type: Boolean,
       optional: true,
@@ -134,6 +139,11 @@ export const RestroomSchema = createSchemaInstance(
     heightOfSoapAndDrier: quantityDefinition(LengthSchema),
     washBasin: {
       type: Object,
+      optional: true,
+      accessibility: {}
+    },
+    'washBasin.isLocatedInsideRestroom': {
+      type: Boolean,
       optional: true,
       accessibility: {}
     },

--- a/src/restroom.ts
+++ b/src/restroom.ts
@@ -18,6 +18,7 @@ export interface Restroom extends Room {
   };
   /// QUESTION undefined vs. null - how do we indicate that there is no mirror?
   mirror?: {
+    isLocatedInsideRestroom?: boolean;
     isAccessibleWhileSeated: boolean;
     heightFromGround: Length;
   };
@@ -42,6 +43,7 @@ export interface Restroom extends Room {
   heightOfSoapAndDrier?: Length;
   /// QUESTION undefined vs. null - how do we indicate that there is no washBasin?
   washBasin?: {
+    isLocatedInsideRestroom?: boolean;
     /// QUESTION is this calculated from the sub-fields or can this go away?
     /// QUESTION is called isAccessibleWithWheelchair in room.ts
     accessibleWithWheelchair?: boolean;

--- a/test/restroom.test.ts
+++ b/test/restroom.test.ts
@@ -17,6 +17,7 @@ const restroomWithOptionalsFixture: Restroom = {
     female: true
   },
   mirror: {
+    isLocatedInsideRestroom: false,
     isAccessibleWhileSeated: true,
     heightFromGround: '100cm'
   },
@@ -31,6 +32,7 @@ const restroomWithOptionalsFixture: Restroom = {
   shower: showerMinimumFixture,
   heightOfSoapAndDrier: '100 .. 120cm',
   washBasin: {
+    isLocatedInsideRestroom: false,
     accessibleWithWheelchair: true,
     height: '>80cm',
     spaceBelow: {
@@ -40,10 +42,7 @@ const restroomWithOptionalsFixture: Restroom = {
   }
 };
 
-const allValidFixtures = Object.freeze([
-  restroomMinimumFixture,
-  restroomWithOptionalsFixture
-]);
+const allValidFixtures = Object.freeze([restroomMinimumFixture, restroomWithOptionalsFixture]);
 
 const invalidRestroomFixture = {
   bar: []


### PR DESCRIPTION
You can use these attributes to indicate that a wash basin/mirror is inside or outside the restroom.
This helps to know if can use a facility without being seen. Information like this is already in use by https://cleanyourcup.com.