### PR TITLE
Update equipment-properties.ts

### DIFF
--- a/src/equipment-properties.ts
+++ b/src/equipment-properties.ts
@@ -3,6 +3,7 @@ import SimpleSchema from 'simpl-schema';
 
 import './simpl-schema-extensions';
 
+import { Door, DoorSchema } from './door';
 import { Length, LengthSchema } from './units';
 import { ExternalId, ExternalIdSchemaDefinition } from './external-id';
 

--- a/src/equipment-properties.ts
+++ b/src/equipment-properties.ts
@@ -123,13 +123,6 @@ export const EquipmentPropertiesSchema = new SimpleSchema({
       componentHint: 'Unit'
     }
   },
-  doorWidth: {
-    type: LengthSchema,
-    optional: true,
-    accessibility: {
-      componentHint: 'Unit'
-    }
-  },
   languages: {
     type: Array,
     defaultValue: [],

--- a/src/equipment-properties.ts
+++ b/src/equipment-properties.ts
@@ -32,8 +32,13 @@ export const AllowedEquipmentTypes = Object.freeze([
 export interface EquipmentProperties {
   // properties
   description?: string;
+  shortDescription?: string;
+  longDescription?: string;
   category?: EquipmentTypes;
-  height?: Length;
+  heightOfControls?: Length;
+  cabinWidth?: Length;
+  cabinLength?: Length;
+  door?: Door;
   languages?: Array<string>;
   isRaised?: boolean;
   isBraille?: boolean;
@@ -78,7 +83,46 @@ export const EquipmentPropertiesSchema = new SimpleSchema({
     type: String,
     optional: true
   },
-  height: {
+  // Alternative description that is screen-reader compatible and replaces abbreviations / symbols with words
+  longDescription: {
+    type: String,
+    optional: true
+  },
+  // Alternative description that uses less screen estate, more abbreviations and Unicode symbols like `→`
+  shortDescription: {
+    type: String,
+    optional: true
+  },
+  heightOfControls: {
+    type: LengthSchema,
+    optional: true,
+    accessibility: {
+      componentHint: 'Unit'
+    }
+  },
+  door: {
+    type: DoorSchema,
+    optional: true,
+    label: t`Door`,
+    accessibility: {
+      questionBlockBegin: t`Would you like to add information about the door of this equipment?`
+    }
+  },
+  cabinWidth: {
+    type: LengthSchema,
+    optional: true,
+    accessibility: {
+      componentHint: 'Unit'
+    }
+  },
+  cabinLength: {
+    type: LengthSchema,
+    optional: true,
+    accessibility: {
+      componentHint: 'Unit'
+    }
+  },
+  doorWidth: {
     type: LengthSchema,
     optional: true,
     accessibility: {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const FormatVersion = '0.5.4';
+export const FormatVersion = '1.5.4';

--- a/test/equipment-properties.test.ts
+++ b/test/equipment-properties.test.ts
@@ -4,14 +4,20 @@ import {
   EquipmentPropertiesSchema,
   EquipmentTypes
 } from '../src/equipment-properties';
+import { doorMinimumFixture } from './door.test';
 import { validExternalIdWithExtendedDataFixture } from './external-id.test';
 
 export const equipmentPropertiesMinimumFixture: EquipmentProperties = {};
 
 const equipmentPropertiesFixture: EquipmentProperties = {
   description: 'string',
+  longDescription: 'long string',
+  shortDescription: 's.',
   category: 'elevator',
-  height: '90 .. 120cm',
+  door: doorMinimumFixture,
+  heightOfControls: '90 .. 120cm',
+  cabinWidth: '100cm',
+  cabinLength: '120cm',
   languages: ['en', 'de'],
   isRaised: true,
   isBraille: true,


### PR DESCRIPTION
This adds equipment properties that we get from some equipment sources.

Hamburg's transport agency HVV delivers these values, for example:
```javascript
{
  lines: [ 'U2', 'U4' ],
  label: 'D',
  cabinWidth: 123,
  cabinLength: 210,
  doorWidth: 89,
  description: 'Zwischenebene <-> U2 Ri. Niendorf Nord und U4 Ri. HafenCity Universität',
  elevatorType: 'Durchlader',
  buttonType: 'COMBI',
  state: 'READY',
}
```

`longDescription` allows to translate the description to an `aria-label` attribute. Many elevators/escalators have descriptions that would not be readable by a screen reader (like 'Zw.Ebene Potsdamer Str. <> 1.UG Gl. 4/5 Ri. stadtauswärts'). The import flow adds some intelligence here.

`shortDescription` allows to add a description that is more visually pleasing when showing a whole list of equipments at the same place, like 'Parkhaus ↗︎ 1. UG' instead of 'von Parkhaus aufwährtsführend zu 1. UG'.

Do the attribute names make sense to you or would you rather use something like `shortenedDescription` and `descriptionAriaLabel`?

I also changed `height` to `heightOfControls` because for an elevator, the name might be interpreted as referring to the cabin height.